### PR TITLE
remove promotion and self reference from friends

### DIFF
--- a/models/session.js
+++ b/models/session.js
@@ -59,7 +59,9 @@ function Session (client, params) {
   self.discoverVideoCatalog = discover['video_catalog']
 
   // Friends
-  self.friends = friends.map(function (friend) {
+  self.friends = friends.filter(function (friend) {
+    return friend.name !== updatesResponse['username'] && friend.expiration === 0
+  }).map(function (friend) {
     return new User(friend)
   })
 


### PR DESCRIPTION
Although its based on the results of their API, for me it was confusing to find entries in your friendslist which aren't actually there.