### PR TITLE
handle failed login

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,6 +375,9 @@ Snapchat.prototype.signInWithData = function (data, username, password, cb) {
     }
 
     Request.postCustom(constants.endpoints.account.login, params, headers, null, opts, function (err, result) {
+      if (!result.logged) {
+        err = new Error(result.message)
+      }
       if (err) {
         debug('Snapchat.signIn error %s', err)
         return reject(err)


### PR DESCRIPTION
An unusual status (-103) got send in the body on a temporary failed login.