### PR TITLE
cache authentication tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -1012,3 +1012,25 @@ Snapchat.prototype._getClientAuthToken = function (username, password, ts, cb) {
 
   }).nodeify(cb)
 }
+
+/**
+ * Removes previously cached values
+ *
+ * @param {string} Optional username The Snapchat username to sign in with.
+ * @param {string} Optional password The password to the Snapchat account to sign in with.
+ * @param {string} Optional gmailEmail A valid GMail address.
+ * @param {string} Optional gmailPassword The password associated with gmailEmail.
+ *
+ * @private
+ */
+Snapchat.prototype._clearCache = function (username, password, gmailEmail, gmailPassword) {
+  if (!(username && password && gmailEmail && gmailPassword)) {
+    return configs.clear()
+  }
+  if (username && password) {
+    configs.del(StringUtils.hashHMacToBase64(username, password))
+  }
+  if (gmailEmail && gmailPassword) {
+    configs.del(StringUtils.hashHMacToBase64(gmailEmail, gmailPassword))
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "async": "^1.4.2",
     "bignum": "^0.11.0",
     "bluebird": "^2.9.34",
+    "configstore": "^1.2.1",
     "debug": "^2.1.0",
     "enum": "^2.1.0",
     "file-type": "^2.10.2",


### PR DESCRIPTION
Thought after the latest [login issue](https://www.facebook.com/casper4snapchat/posts/1613433835589538) its probably best to cache the authentication tokens by default. Clearing would currently be manually or perhaps later via ignore flag.